### PR TITLE
Fix: 필터링 시 데이터 페칭 에러 수정

### DIFF
--- a/src/actions/youtube/video.action.ts.ts
+++ b/src/actions/youtube/video.action.ts.ts
@@ -16,15 +16,15 @@ export async function getVideos({
     // 랭킹 조회 (일간/주간)
     if (['daily', 'weekly'].includes(rankType)) {
       const functionName = rankType === 'daily' ? 'get_daily_rankings' : 'get_weekly_rankings';
-
       const { data, error } = await supabase.rpc(functionName, {
         p_playlist_type: playlistType === 'all' ? null : playlistType,
       });
       if (error) throw error;
+      console.log(data.length);
 
       // 페이지네이션 적용
       const paginatedData = data.slice(offset, offset + limit);
-
+      // console.log(paginatedData);
       return {
         videos: paginatedData,
         totalCount: data.length,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,8 @@ import { HomeSkeleton } from './components/homeSkeleton';
 import { fetchYoutubeChannels } from '@/actions/youtube/youtubeThumbnails.action';
 import { Navbar } from '@/components/common/navBar';
 import { getVideos } from '@/actions/youtube/video.action.ts';
-import { fetchYoutubeVideos } from '@/actions/youtube/youtube.action';
 
 export default async function PlaylistViewer() {
-  await fetchYoutubeVideos();
   const [latestVideos, topVideo, initialChannel] = await Promise.all([
     getVideos({ sortBy: 'date' }),
     getVideos({ sortBy: 'views', limit: 5 }),

--- a/src/app/ranking/components/videoRankingSection/section.tsx
+++ b/src/app/ranking/components/videoRankingSection/section.tsx
@@ -6,7 +6,7 @@ export default function Section({ videos, filters, toggleMusic, selectedMusic })
     <div className="space-y-4">
       {videos.map((video, index) => (
         <Card
-          key={video.video_id}
+          key={`${video.video_id}_${index}`}
           video={video}
           index={index}
           filters={filters}

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -10,14 +10,15 @@ export default async function page({ searchParams }) {
     rankType: (searchParams.rankType as VideoFilters['rankType']) || FILTER_OPTIONS.RANK_TYPE.TOTAL,
     playlistType: (searchParams.playlistType as VideoFilters['playlistType']) || FILTER_OPTIONS.PLAYLIST_TYPE.ALL,
   };
-
   const initialData = await getVideos({
     sortBy: initialFilters.sort,
     rankType: initialFilters.rankType,
     playlistType: initialFilters.playlistType,
-    limit: 50,
+    limit: 30,
     offset: 0,
   });
+  // console.log(initialData);
+
   return (
     <Suspense fallback={<RankingSkeleton />}>
       <Ui initialData={initialData} initialFilters={initialFilters} />

--- a/src/app/ranking/ui.tsx
+++ b/src/app/ranking/ui.tsx
@@ -11,7 +11,6 @@ export default function Ui({ initialData, initialFilters }) {
   const [selectedMusic, setSelectedMusic] = useState<Set<string>>(() => new Set());
   const { filters, updateFilter } = useVideoFilters(initialFilters);
   const MAX_SELECTION = 50;
-
   const { videos, isLoading, hasMore, loadMoreRef, containerRef } = useInfiniteScroll({
     initialData,
     filters: {
@@ -48,7 +47,7 @@ export default function Ui({ initialData, initialFilters }) {
       <div ref={loadMoreRef} className="h-10 w-full">
         {isLoading && (
           <div className="flex justify-center py-4">
-            <span>Loading...</span>
+            <div className="animate-spin h-8 w-8 border-4 border-brand-primary border-t-transparent rounded-full"></div>
           </div>
         )}
       </div>


### PR DESCRIPTION
- 현재 데이터 페칭자체가 문제 발생 원인 찾는중 Github issue #27

## #️⃣연관된 이슈

> ex) #27 

## 📝작업 내용
> 필터 적용시 순위가 제대로 나오지않았던 부분을 아래와 같이 수정
```
// 랭킹 section 에서 key값을 개별로 제공
 <div className="space-y-4">
      {videos.map((video, index) => (
        <Card
          key={`${video.video_id}_${index}`}
          video={video}
          index={index}
          filters={filters}
          toggleMusic={toggleMusic}
          selectedMusic={selectedMusic}
        />
      ))}
    </div>
```
> 추가로 필터 적용시 무한스크롤이 자동으로 발생하는 문제 발생 => 특정 필터에서 스크롤이 아래있을때 필터 적용하면 한번 데이터패칭이 바로 일어났음
```
     // 1.
      if (timeoutRef.current) {
        clearTimeout(timeoutRef.current);
      }

      resetScroll();

    // 2. 
      timeoutRef.current = setTimeout(() => {
        timeoutRef.current = null;
      }, 1000);
    }
  ```
해결 1. clearTimeout(timeoutRef.current)을 통해 이전에 예약된 데이터 로딩 작업을 취소함. 필터가 변경되었을 때 이전 필터의 데이터가 로드되는 것을 방지
해결 2. 필터 변경 직후 약 1초 동안 새로운 데이터 로딩을 방지. timeoutRef가 null이 아닌 동안에는 loadMore 함수가 실행되지 않기 때문에, 스크롤이 상단으로 이동하는 동안 발생할 수 있는 불필요한 데이터 로딩을 방지